### PR TITLE
Fix typos.

### DIFF
--- a/aframe-based-tile-player/app/main.js
+++ b/aframe-based-tile-player/app/main.js
@@ -480,7 +480,7 @@ app.controller('DashController', ['$scope','$interval', function ($scope, $inter
                             'bufferToKeep': $scope.playerBufferToKeep,
                             'stableBufferTime': $scope.playerStableBufferTime,
                             'bufferTimeAtTopQuality': $scope.playerBufferTimeAtTopQuality,
-                            'fastswitchenabled': true,
+                            'fastSwitchEnabled': true,
                             'liveDelay': 0, 
                             'liveCatchup': {
                                 'enabled': true,
@@ -704,7 +704,7 @@ app.controller('DashController', ['$scope','$interval', function ($scope, $inter
                     $scope.stats.push({
                         playerid : "audio",
                         bufferlevel : $scope.playerBufferLength[i].toFixed(2) + " s",
-                        throughput : $scope.playerAverageThroughput[i].toFixed(0)+ " bps",
+                        throughput : $scope.playerAverageThroughput[i].toFixed(0)+ " kbps",
                         time : $scope.playerTime[i].toFixed(2) + " s",
                         quality : $scope.players[i].getQualityFor("audio").toFixed(0),
                         fovscore : NaN,
@@ -724,7 +724,7 @@ app.controller('DashController', ['$scope','$interval', function ($scope, $inter
                 $scope.stats.push({
                     playerid : "video_" + i,
                     bufferlevel : $scope.playerBufferLength[i].toFixed(2) + " s",
-                    throughput : $scope.playerAverageThroughput[i].toFixed(0)+ " bps",
+                    throughput : $scope.playerAverageThroughput[i].toFixed(0)+ " kbps",
                     time : $scope.playerTime[i].toFixed(2) + " s",
                     quality : $scope.playerDownloadingQuality[i].toFixed(0),
                     fovscore : $scope.playerFOVScore[i].toFixed(0),


### PR DESCRIPTION
fastswitchenabled -> fastSwitchEnabled

and

throughput should be kbps according to 
https://github.com/InRaysee/vr-dash-tile-player/blob/ea798e02c1c12eda62ae2933302ba2cdf8da0690/aframe-based-tile-player/dash.js/src/streaming/rules/ThroughputHistory.js#L35-L36